### PR TITLE
Template of PSP project

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+    "name": "Light Protocol",
+    "image": "ghcr.io/lightprotocol/devcontainer:main",
+    "mounts": [
+        // Solana keypair.
+        {
+            "source": "lightprotocol-solana-config-${devcontainerId}",
+            "target": "/home/node/.config/solana",
+            "type": "volume"
+        }
+    ],
+    // Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+    // "mounts": [
+    // 	{
+    // 		"source": "devcontainer-cargo-cache-${devcontainerId}",
+    // 		"target": "/usr/local/cargo",
+    // 		"type": "volume"
+    // 	}
+    // ]
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "rustc --version",
+    // Configure tool-specific properties.
+    // "customizations": {},
+    "remoteUser": "node"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.anchor
+.DS_Store
+target
+**/*.rs.bk
+node_modules
+test-ledger
+.yarn
+lookUpTable.txt

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+.anchor
+.DS_Store
+target
+node_modules
+dist
+build
+test-ledger
+build-circuit

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,0 +1,16 @@
+[features]
+seeds = false
+skip-lint = false
+
+[programs.localnet]
+{{project-name}} = "{{program-id}}"
+
+[registry]
+url = "https://api.apr.dev"
+
+[provider]
+cluster = "Localnet"
+wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/test.ts --exit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,20 @@
+[workspace]
+members = [
+    "programs/*"
+]
+
+[profile.release]
+overflow-checks = true
+lto = "fat"
+codegen-units = 1
+
+[profile.release.build-override]
+opt-level = 3
+incremental = false
+codegen-units = 1
+
+[patch.crates-io]
+anchor-lang = { git = "https://github.com/Lightprotocol/anchor", branch = "v0.26.0-deps-version-fix" }
+anchor-spl = { git = "https://github.com/Lightprotocol/anchor", branch = "v0.26.0-deps-version-fix" }
+solana-program = { git = "https://github.com/Lightprotocol/solana", branch="v1.15" }
+solana-zk-token-sdk = { git = "https://github.com/Lightprotocol/solana", branch="v1.15" }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# psp-template
+# {{project-name}}

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,15 @@
+[template]
+cargo_generate_version = ">=0.18.2"
+
+[placeholders.circom-name]
+type = "string"
+prompt = "Name of the Circom circuit (snake_case)"
+
+[placeholders.rust-name]
+type = "string"
+prompt = "Name of the Rust crate (snake_case)"
+
+[placeholders.program-id]
+type = "string"
+prompt = "Solana program ID"
+default = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"

--- a/circuit/{{circom-name}}.light
+++ b/circuit/{{circom-name}}.light
@@ -1,0 +1,26 @@
+pragma circom 2.1.4;
+include "../node_modules/circomlib/circuits/poseidon.circom";
+include "../node_modules/@lightprotocol/zk.js/circuit-lib/merkleProof.circom";
+include "../node_modules/@lightprotocol/zk.js/circuit-lib/keypair.circom";
+include "../node_modules/circomlib/circuits/gates.circom";
+include "../node_modules/circomlib/circuits/comparators.circom";
+
+// will create a new instance of the circuit
+#[instance]
+{
+    fileName: {{circom-name}},
+    config(),
+    nrAppUtoxs: 1,
+    publicInputs: [currentSlot]
+}
+
+#[lightTransaction(verifierTwo)]
+template {{circom-name}}() {
+    // Defines the data which is saved in the utxo
+    #[utxoData]
+    {
+        releaseSlot
+    }
+    signal input currentSlot;
+    currentSlot === releaseSlot;
+}

--- a/migrations/deploy.ts
+++ b/migrations/deploy.ts
@@ -1,0 +1,12 @@
+// Migrations are an early feature. Currently, they're nothing more than this
+// single deploy script that's invoked from the CLI, injecting a provider
+// configured from the workspace's Anchor.toml.
+
+const anchor = require("@coral-xyz/anchor");
+
+module.exports = async function (provider) {
+  // Configure client to use the provider.
+  anchor.setProvider(provider);
+
+  // Add your deploy script here.
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "scripts": {
+    "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
+    "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check",
+    "test": "light test --projectName {{project-name}} --programAddress {{program-id}}",
+    "build": "light build --name {{project-name}}"
+  },
+  "dependencies": {
+    "@coral-xyz/anchor": "^0.27.0",
+    "circomlib": "^2.0.5",
+    "circomlibjs": "^0.1.7",
+    "@lightprotocol/zk.js": "^0.3.2-alpha.8"
+  },
+  "devDependencies": {
+    "chai": "^4.3.4",
+    "mocha": "^9.0.3",
+    "ts-mocha": "^10.0.0",
+    "@types/bn.js": "^5.1.0",
+    "@types/chai": "^4.3.0",
+    "@types/mocha": "^9.0.0",
+    "typescript": "^4.3.5",
+    "prettier": "^2.6.2"
+  }
+}

--- a/programs/{{project-name}}/Cargo.toml
+++ b/programs/{{project-name}}/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "{{rust-name}}"
+version = "0.1.0"
+description = "Created with Light Protocol"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "{{rust-name}}"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = "0.26.0"
+anchor-spl = "0.26.0"
+merkle_tree_program = { git = "https://github.com/lightprotocol/light-protocol", features = ["cpi"], rev = "a76187f450cb946881e2ca598027dfa850acaa38" }
+verifier_program_two = { git = "https://github.com/lightprotocol/light-protocol", features = ["cpi"], rev = "a76187f450cb946881e2ca598027dfa850acaa38" }
+light-macros = "0.1.0"
+light-verifier-sdk = { git = "https://github.com/lightprotocol/light-protocol", rev = "a76187f450cb946881e2ca598027dfa850acaa38" }
+solana-program = "1.15.2"
+groth16-solana = "0.0.1"

--- a/programs/{{project-name}}/Xargo.toml
+++ b/programs/{{project-name}}/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/programs/{{project-name}}/src/lib.rs
+++ b/programs/{{project-name}}/src/lib.rs
@@ -1,0 +1,113 @@
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::keccak::hash;
+
+pub mod light_utils;
+pub use light_utils::*;
+pub mod processor;
+pub use processor::*;
+pub mod verifying_key;
+pub use verifying_key::*;
+
+use crate::processor::{
+    process_psp_instruction_first, process_psp_instruction_third,
+};
+
+declare_id!("{{program-id}}");
+
+#[constant]
+pub const PROGRAM_ID: &str = "{{program-id}}";
+
+#[program]
+pub mod {{rust-name}} {
+    use super::*;
+
+    /// The first step of a shieled transaction. It creates and initializes a
+    /// verifier state account to save state of a verification during
+    /// computation verifying the zero-knowledge proof (ZKP). Additionally, it
+    /// stores other data such as leaves, amounts, recipients, nullifiers, etc.
+    /// to execute the protocol logic in the last transaction after successful
+    /// ZKP verification.
+    pub fn psp_instruction_first<'a, 'b, 'c, 'info>(
+        ctx: Context<'a, 'b, 'c, 'info, PspInstructionFirst<'info>>,
+        inputs: Vec<u8>,
+    ) -> Result<()> {
+        let inputs_des: InstructionDataPspInstructionFirst =
+            InstructionDataPspInstructionFirst::try_deserialize_unchecked(
+                &mut inputs.as_slice(),
+            )?;
+        let proof_a = [0u8; 64];
+        let proof_b = [0u8; 128];
+        let proof_c = [0u8; 64];
+        let pool_type = [0u8; 32];
+        let checked_inputs = vec![
+            [
+                vec![0u8],
+                hash(&ctx.program_id.to_bytes()).try_to_vec()?[1..].to_vec(),
+            ]
+            .concat(),
+            inputs_des.transaction_hash.to_vec(),
+        ];
+        process_psp_instruction_first(
+            ctx,
+            &proof_a,
+            &proof_b,
+            &proof_c,
+            &inputs_des.public_amount_spl,
+            &inputs_des.input_nullifier,
+            &inputs_des.output_commitment,
+            &inputs_des.public_amount_sol,
+            &checked_inputs,
+            &inputs_des.encrypted_utxos,
+            &pool_type,
+            &inputs_des.root_index,
+            &inputs_des.relayer_fee,
+        )
+    }
+
+    pub fn psp_instruction_second<'a, 'b, 'c, 'info>(
+        ctx: Context<'a, 'b, 'c, 'info, PspInstructionSecond<'info>>,
+        inputs: Vec<u8>,
+    ) -> Result<()> {
+        // cut off discriminator
+        let vec = &inputs[8..];
+        let _ = vec
+            .chunks(32)
+            .map(|input| {
+                ctx.accounts
+                    .verifier_state
+                    .checked_public_inputs
+                    .push(input.to_vec())
+            })
+            .collect::<Vec<_>>();
+        Ok(())
+    }
+
+    /// The third and final step of a shielded transaction. The proof is
+    /// verified with the parameters saved in the first transaction. At
+    /// successful verification, protocol logic is executed.
+    pub fn psp_instruction_third<'a, 'b, 'c, 'info>(
+        ctx: Context<'a, 'b, 'c, 'info, PspInstructionThird<'info>>,
+        inputs: Vec<u8>,
+    ) -> Result<()> {
+        let inputs_des: InstructionDataPspInstructionThird =
+            InstructionDataPspInstructionThird::try_deserialize(&mut inputs.as_slice())?;
+
+        process_psp_instruction_third(
+            ctx,
+            &inputs_des.proof_a_app,
+            &inputs_des.proof_b_app,
+            &inputs_des.proof_c_app,
+            &inputs_des.proof_a,
+            &inputs_des.proof_b,
+            &inputs_des.proof_c,
+        )
+    }
+
+    /// Close the verifier state to reclaim rent in case the proof does not
+    /// verify.
+    pub fn close_verifier_state<'a, 'b, 'c, 'info>(
+        _ctx: Context<'a, 'b, 'c, 'info, CloseVerifierState<'info>>,
+    ) -> Result<()> {
+        Ok(())
+    }
+}

--- a/programs/{{project-name}}/src/processor.rs
+++ b/programs/{{project-name}}/src/processor.rs
@@ -1,0 +1,163 @@
+use anchor_lang::prelude::*;
+use solana_program::sysvar;
+
+use light_macros::pubkey;
+use light_verifier_sdk::light_transaction::VERIFIER_STATE_SEED;
+use light_verifier_sdk::{
+    light_app_transaction::AppTransaction,
+    light_transaction::{Config, Transaction},
+};
+
+use crate::{verifying_key::VERIFYINGKEY, PspInstructionFirst, PspInstructionThird};
+
+#[derive(Clone)]
+pub struct TransactionsConfig;
+impl Config for TransactionsConfig {
+    /// Number of nullifiers to be inserted with the transaction.
+    const NR_NULLIFIERS: usize = 4;
+    /// Number of output utxos.
+    const NR_LEAVES: usize = 4;
+    /// ProgramId.
+    const ID: Pubkey = pubkey!("{{program-id}}");
+}
+
+pub fn process_psp_instruction_first<'a, 'b, 'c, 'info>(
+    ctx: Context<'a, 'b, 'c, 'info, PspInstructionFirst<'info>>,
+    proof_a: &'a [u8; 64],
+    proof_b: &'a [u8; 128],
+    proof_c: &'a [u8; 64],
+    public_amount_spl: &'a [u8; 32],
+    input_nullifier: &'a [[u8; 32]; 4],
+    output_commitment: &'a [[u8; 32]; 4],
+    public_amount_sol: &'a [u8; 32],
+    checked_public_inputs: &'a Vec<Vec<u8>>,
+    encrypted_utxos: &'a Vec<u8>,
+    pool_type: &'a [u8; 32],
+    root_index: &'a u64,
+    relayer_fee: &'a u64,
+) -> Result<()> {
+    let output_commitment = [
+        [output_commitment[0], output_commitment[1]],
+        [output_commitment[2], output_commitment[3]],
+    ];
+    let tx = Transaction::<2, 4, TransactionsConfig>::new(
+        None,
+        None,
+        proof_a,
+        proof_b,
+        proof_c,
+        public_amount_spl,
+        public_amount_sol,
+        checked_public_inputs,
+        input_nullifier,
+        &output_commitment,
+        encrypted_utxos,
+        *relayer_fee,
+        (*root_index).try_into().unwrap(),
+        pool_type, //pool_type
+        None,
+        &VERIFYINGKEY,
+    );
+    ctx.accounts.verifier_state.set_inner(tx.into());
+    ctx.accounts.verifier_state.signer = *ctx.accounts.signing_address.key;
+    Ok(())
+}
+
+pub fn process_psp_instruction_third<'a, 'b, 'c, 'info>(
+    ctx: Context<'a, 'b, 'c, 'info, PspInstructionThird<'info>>,
+    proof_a_app: &'a [u8; 64],
+    proof_b_app: &'a [u8; 128],
+    proof_c_app: &'a [u8; 64],
+    proof_a_verifier: &'a [u8; 64],
+    proof_b_verifier: &'a [u8; 128],
+    proof_c_verifier: &'a [u8; 64],
+) -> Result<()> {
+    // enforce current slot public input
+    let current_slot = <Clock as sysvar::Sysvar>::get()?.slot;
+    msg!(
+        "{} > {}",
+        current_slot,
+        u64::from_be_bytes(
+            ctx.accounts.verifier_state.checked_public_inputs[2][24..32]
+                .try_into()
+                .unwrap(),
+        )
+    );
+    if current_slot
+        < u64::from_be_bytes(
+            ctx.accounts.verifier_state.checked_public_inputs[2][24..32]
+                .try_into()
+                .unwrap(),
+        )
+    {
+        panic!("Escrow still locked");
+    }
+    // verify app proof
+    let mut app_verifier = AppTransaction::<TransactionsConfig>::new(
+        proof_a_app,
+        proof_b_app,
+        proof_c_app,
+        ctx.accounts.verifier_state.checked_public_inputs.clone(),
+        &VERIFYINGKEY,
+    );
+
+    app_verifier.verify()?;
+
+    let (_, bump) = anchor_lang::prelude::Pubkey::find_program_address(
+        &[
+            ctx.accounts.signing_address.key().to_bytes().as_ref(),
+            VERIFIER_STATE_SEED.as_ref(),
+        ],
+        ctx.program_id,
+    );
+
+    let bump = &[bump];
+    let accounts = verifier_program_two::cpi::accounts::LightInstruction {
+        verifier_state: ctx.accounts.verifier_state.to_account_info().clone(),
+        signing_address: ctx.accounts.signing_address.to_account_info().clone(),
+        authority: ctx.accounts.authority.to_account_info().clone(),
+        system_program: ctx.accounts.system_program.to_account_info().clone(),
+        registered_verifier_pda: ctx
+            .accounts
+            .registered_verifier_pda
+            .to_account_info()
+            .clone(),
+        program_merkle_tree: ctx.accounts.program_merkle_tree.to_account_info().clone(),
+        transaction_merkle_tree: ctx
+            .accounts
+            .transaction_merkle_tree
+            .to_account_info()
+            .clone(),
+        token_program: ctx.accounts.token_program.to_account_info().clone(),
+        sender_spl: ctx.accounts.sender_spl.to_account_info().clone(),
+        recipient_spl: ctx.accounts.recipient_spl.to_account_info().clone(),
+        sender_sol: ctx.accounts.sender_sol.to_account_info().clone(),
+        recipient_sol: ctx.accounts.recipient_sol.to_account_info().clone(),
+        // relayer recipient and escrow will never be used in the same transaction
+        relayer_recipient_sol: ctx.accounts.relayer_recipient_sol.to_account_info().clone(),
+        token_authority: ctx.accounts.token_authority.to_account_info().clone(),
+        log_wrapper: ctx.accounts.log_wrapper.to_account_info(),
+    };
+
+    let seed = &ctx.accounts.signing_address.key().to_bytes();
+    let domain_separation_seed = VERIFIER_STATE_SEED;
+    let cpi_seed = &[seed, domain_separation_seed, bump];
+    let final_seed = &[&cpi_seed[..]];
+    let mut cpi_ctx = CpiContext::new_with_signer(
+        ctx.accounts.verifier_program.to_account_info().clone(),
+        accounts,
+        final_seed,
+    );
+    cpi_ctx = cpi_ctx.with_remaining_accounts(ctx.remaining_accounts.to_vec());
+
+    verifier_program_two::cpi::shielded_transfer_inputs(
+        cpi_ctx,
+        *proof_a_verifier,
+        *proof_b_verifier,
+        *proof_c_verifier,
+        <Vec<u8> as TryInto<[u8; 32]>>::try_into(
+            ctx.accounts.verifier_state.checked_public_inputs[1].to_vec(),
+        )
+        .unwrap(),
+    )
+}

--- a/tests/{{project-name}}.ts
+++ b/tests/{{project-name}}.ts
@@ -1,0 +1,139 @@
+import * as anchor from "@coral-xyz/anchor";
+import { assert } from "chai";
+import {
+  Utxo,
+  Transaction,
+  TRANSACTION_MERKLE_TREE_KEY,
+  TransactionParameters,
+  Provider as LightProvider,
+  confirmConfig,
+  Action,
+  TestRelayer,
+  User,
+  ProgramUtxoBalance,
+  airdropSol,
+  LOOK_UP_TABLE,
+  verifierProgramStorageProgramId,
+  verifierProgramTwoProgramId,
+  ProgramParameters
+} from "@lightprotocol/zk.js";
+import {
+  SystemProgram,
+  PublicKey,
+  Keypair,
+} from "@solana/web3.js";
+
+import { buildPoseidonOpt } from "circomlibjs";
+import { BN } from "@coral-xyz/anchor";
+import { IDL } from "../target/types/{{rust-name}}";
+const path = require("path");
+
+const verifierProgramId = new PublicKey(
+  "{{program-id}}",
+);
+var POSEIDON;
+
+const RPC_URL = "http://127.0.0.1:8899";
+
+describe("{}", () => {
+  process.env.ANCHOR_PROVIDER_URL = RPC_URL;
+  process.env.ANCHOR_WALLET = process.env.HOME + "/.config/solana/id.json";
+
+  // Configure the client to use the local cluster.
+  const provider = anchor.AnchorProvider.local(RPC_URL, confirmConfig);
+  anchor.setProvider(provider);
+
+  before(async () => {
+    POSEIDON = await buildPoseidonOpt();
+  });
+
+
+  it("Create and Spend Program Utxo ", async () => {
+    const wallet = Keypair.generate();
+    await airdropSol({
+      provider,
+      amount: 10_000_000_000,
+      recipientPublicKey: wallet.publicKey,
+    });
+
+    let relayer = new TestRelayer(wallet.publicKey, LOOK_UP_TABLE, wallet.publicKey, new BN(100000))
+    await airdropSol({
+      provider,
+      amount: 1_000_000_000,
+      recipientPublicKey: Transaction.getRegisteredVerifierPda(
+        TRANSACTION_MERKLE_TREE_KEY,
+        verifierProgramStorageProgramId
+      ),
+    });
+    await airdropSol({
+      provider,
+      amount: 1_000_000_000,
+      recipientPublicKey: Transaction.getRegisteredVerifierPda(
+        TRANSACTION_MERKLE_TREE_KEY,
+        verifierProgramTwoProgramId
+      ),
+    });
+
+    // The light provider is a connection and wallet abstraction.
+    // The wallet is used to derive the seed for your shielded keypair with a signature.
+    var lightProvider = await LightProvider.init({ wallet, url: RPC_URL, relayer });
+    lightProvider.addVerifierProgramPublickeyToLookUpTable(TransactionParameters.getVerifierProgramId(IDL));
+
+    const user: User = await User.init({ provider: lightProvider });
+
+    const outputUtxoSol = new Utxo({
+      poseidon: POSEIDON,
+      assets: [SystemProgram.programId],
+      account: user.account,
+      amounts: [new BN(1_000_000)],
+      appData: { releaseSlot: new BN(1) },
+      appDataIdl: IDL,
+      verifierAddress: verifierProgramId,
+      assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
+      verifierProgramLookupTable: lightProvider.lookUpTables.verifierProgramLookupTable
+    });
+
+    const testInputsShield = {
+      utxo: outputUtxoSol,
+      action: Action.SHIELD,
+    }
+
+    let storeTransaction = await user.storeAppUtxo({
+      appUtxo: testInputsShield.utxo,
+      action: testInputsShield.action,
+    });
+    console.log("store program utxo transaction hash ", storeTransaction.txHash);
+
+    const programUtxoBalance: Map<string, ProgramUtxoBalance> =
+      await user.syncStorage(IDL);
+    const shieldedUtxoCommitmentHash =
+      testInputsShield.utxo.getCommitment(POSEIDON);
+    const inputUtxo = programUtxoBalance
+      .get(verifierProgramId.toBase58())
+      .tokenBalances.get(testInputsShield.utxo.assets[1].toBase58())
+      .utxos.get(shieldedUtxoCommitmentHash);
+
+    Utxo.equal(POSEIDON, inputUtxo, testInputsShield.utxo, true);
+
+    const circuitPath = path.join("build-circuit");
+
+    const programParameters: ProgramParameters = {
+      inputs: {
+        releaseSlot: inputUtxo.appData.releaseSlot,
+        currentSlot: inputUtxo.appData.releaseSlot // for testing we can use the same value
+      },
+      verifierIdl: IDL,
+      path: circuitPath
+    };
+
+    let { txHash } = await user.executeAppUtxo({
+      appUtxo: inputUtxo,
+      programParameters,
+      action: Action.TRANSFER,
+    });
+    console.log("transaction hash ", txHash);
+    const utxoSpent = await user.getUtxo(inputUtxo.getCommitment(POSEIDON), true, IDL);
+    assert.equal(utxoSpent.status, "spent");
+    Utxo.equal(POSEIDON, utxoSpent.utxo, inputUtxo, true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "types": [
+      "mocha",
+      "chai"
+    ],
+    "typeRoots": [
+      "./node_modules/@types"
+    ],
+    "lib": [
+      "es2015"
+    ],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
This is a template for Private Solana Programs which can be generated with cargo-generate[0].

Example usage:

```
cargo generate --git https://github.com/Lightprotocol/psp-template
```

cargo-generate can be also used as a Rust library[1], which is what we are going to do in the light-anchor CLI, to avoid hard coding of the template.

[0] https://crates.io/crates/cargo-generate
[1] https://docs.rs/cargo-generate/0.18.2/cargo_generate/fn.generate.html