### PR TITLE
fix checked_inputs shape

### DIFF
--- a/programs/{{project-name}}/src/lib.rs
+++ b/programs/{{project-name}}/src/lib.rs
@@ -46,19 +46,20 @@ pub mod {{rust-name}} {
         let pool_type = [0u8; 32];
         let mut program_id_hash = hash(&ctx.program_id.to_bytes()).to_bytes();
         program_id_hash[0] = 0;
-        let checked_inputs = [
+        let mut checked_inputs = [
             program_id_hash,
             inputs_des.transaction_hash,
-            // inputs_des.current_slot.to_vec(),
-            [0u8; 32],
         ];
+        for _ in 2..NR_CHECKED_INPUTS {
+            checked_inputs.push([0u8; 32]);
+        }
         process_psp_instruction_first::<NR_CHECKED_INPUTS, 17>(
             ctx,
             &proof,
             &public_amount,
             &inputs_des.input_nullifier,
             &inputs_des.output_commitment,
-            &checked_inputs,
+            &checked_inputs.try_into().unwrap(),
             &inputs_des.encrypted_utxos,
             &pool_type,
             &inputs_des.root_index,
@@ -78,7 +79,7 @@ pub mod {{rust-name}} {
         Ok(())
     }
 
-    /// This instruction is the second step of a shieled transaction.
+    /// This instruction is the second step of a shielded transaction.
     /// The proof is verified with the parameters saved in the first transaction.
     /// At successful verification protocol logic is executed.
     pub fn light_instruction_third<'a, 'b, 'c, 'info>(

--- a/programs/{{project-name}}/src/lib.rs
+++ b/programs/{{project-name}}/src/lib.rs
@@ -46,20 +46,18 @@ pub mod {{rust-name}} {
         let pool_type = [0u8; 32];
         let mut program_id_hash = hash(&ctx.program_id.to_bytes()).to_bytes();
         program_id_hash[0] = 0;
-        let mut checked_inputs = [
-            program_id_hash,
-            inputs_des.transaction_hash,
-        ];
-        for _ in 2..NR_CHECKED_INPUTS {
-            checked_inputs.push([0u8; 32]);
-        }
+        
+        let mut checked_inputs: [[u8; 32]; NR_CHECKED_INPUTS] = [[0u8; 32]; NR_CHECKED_INPUTS];
+        checked_inputs[0] = program_id_hash;
+        checked_inputs[1] = inputs_des.transaction_hash;
+
         process_psp_instruction_first::<NR_CHECKED_INPUTS, 17>(
             ctx,
             &proof,
             &public_amount,
             &inputs_des.input_nullifier,
             &inputs_des.output_commitment,
-            &checked_inputs.try_into().unwrap(),
+            &checked_inputs,
             &inputs_des.encrypted_utxos,
             &pool_type,
             &inputs_des.root_index,
@@ -79,7 +77,7 @@ pub mod {{rust-name}} {
         Ok(())
     }
 
-    /// This instruction is the second step of a shielded transaction.
+    /// This instruction is the third step of a shielded transaction.
     /// The proof is verified with the parameters saved in the first transaction.
     /// At successful verification protocol logic is executed.
     pub fn light_instruction_third<'a, 'b, 'c, 'info>(


### PR DESCRIPTION
This PR fixes the error:

```
$ light --version
0.1.1-alpha.14

$ light init foobar && cd foobar && yarn install && yarn build
[...]
// no errors

$ sed -i 's/signal input currentSlot;/signal input currentSlot;\n    signal input abc;/g' circuit/foobar.light
$ sed -i 's/publicInputs: \[currentSlot\]/publicInputs: \[currentSlot, abc\]/' circuit/foobar.light

$ cat circuit/foobar.light

pragma circom 2.1.4;
include "../node_modules/circomlib/circuits/poseidon.circom";
include "../node_modules/@lightprotocol/zk.js/circuit-lib/merkleProof.circom";
include "../node_modules/@lightprotocol/zk.js/circuit-lib/keypair.circom";
include "../node_modules/circomlib/circuits/gates.circom";
include "../node_modules/circomlib/circuits/comparators.circom";

// will create a new instance of the circuit
#[instance]
{
    fileName: foobar,
    config(),
    nrAppUtoxs: 1,
    publicInputs: [currentSlot, abc]
}

#[lightTransaction(verifierTwo)]
template foobar() {
    // Defines the data which is saved in the utxo
    #[utxoData]
    {
        releaseSlot
    }
    signal input currentSlot;
    signal input abc;
    currentSlot === releaseSlot;
}

$ yarn build
[...]
error[E0308]: mismatched types
  --> programs/foobar/src/lib.rs:61:13
   |
55 |         process_psp_instruction_first::<NR_CHECKED_INPUTS, 17>(
   |         ------------------------------------------------------ arguments to this function are incorrect
...
61 |             &checked_inputs,
   |             ^^^^^^^^^^^^^^^ expected an array with a fixed size of 4 elements, found one with 3 elements
   |
note: function defined here
  --> programs/foobar/src/processor.rs:26:8
   |
26 | pub fn process_psp_instruction_first<
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
39 |     checked_public_inputs: &'a [[u8; 32]; NR_CHECKED_INPUTS],
   |     --------------------------------------------------------

```