### PR TITLE
fix(tests): defined circuitName

### DIFF
--- a/psp-template/tests_circom/{{project-name}}.ts
+++ b/psp-template/tests_circom/{{project-name}}.ts
@@ -27,7 +27,7 @@ describe("Test {{project-name}}", () => {
       hash: hash,
     };
 
-    const prover = new Prover(IDL, circuitsPath);
+    const prover = new Prover(IDL, circuitsPath, "{{circom-name-camel-case}}");
 
     await prover.addProofInputs(proofInputs);
     await prover.fullProve();

--- a/psp-template/tests_psp/{{project-name}}.ts
+++ b/psp-template/tests_psp/{{project-name}}.ts
@@ -108,7 +108,8 @@ describe("Test {{project-name}}", () => {
         publicZ: inputUtxo.appData.x.add(inputUtxo.appData.y)
       },
       verifierIdl: IDL,
-      path: circuitPath
+      path: circuitPath,
+      circuitName: "{{circom-name-camel-case}}",
     };
 
     let { txHash } = await user.executeAppUtxo({


### PR DESCRIPTION
- circuit name was not defined in test files
- tests still worked because I left functionality which searches for a circuit and takes the first it finds for backwards compatibility