### PR TITLE
refactor(program): Use `light_verifier_accounts` macro

### DIFF
--- a/psp-template/cargo-generate.toml
+++ b/psp-template/cargo-generate.toml
@@ -32,6 +32,18 @@ prompt = "Prover js version"
 type = "string"
 prompt = "zk js version"
 
+[placeholders.light-system-programs-version]
+type = "string"
+prompt = "On-chain programs version"
+
+[placeholders.light-macros-version]
+type = "string"
+prompt = "light-macros version"
+
+[placeholders.light-verifier-sdk-version]
+type = "string"
+prompt = "Light Verifier SDK version"
+
 [placeholders.type-prefix]
 type = "string"
 prompt = "Sub cli type (psp, circom)"

--- a/psp-template/programs_psp/{{project-name}}/Cargo.toml
+++ b/psp-template/programs_psp/{{project-name}}/Cargo.toml
@@ -18,9 +18,9 @@ default = []
 [dependencies]
 anchor-lang = "0.28.0"
 anchor-spl = "0.28.0"
-merkle_tree_program = { git = "https://github.com/lightprotocol/light-protocol", features = ["cpi"], tag = "v0.3.2" }
-verifier_program_two = { git = "https://github.com/lightprotocol/light-protocol", features = ["cpi"], tag = "v0.3.2" }
-light-macros = "0.1.0"
-light-verifier-sdk = { git = "https://github.com/lightprotocol/light-protocol", tag = "v0.3.2" }
+merkle_tree_program = {{ light-system-programs-version }}
+verifier_program_two = {{ light-system-programs-version }}
+light-macros = {{ light-macros-version }}
+light-verifier-sdk = {{ light-verifier-sdk-version }}
 solana-program = "1.16.4"
 groth16-solana = "0.0.2"

--- a/psp-template/programs_psp/{{project-name}}/src/psp_accounts.rs
+++ b/psp-template/programs_psp/{{project-name}}/src/psp_accounts.rs
@@ -1,10 +1,8 @@
 use crate::processor::TransactionsConfig;
 use anchor_lang::prelude::*;
-use anchor_spl::token::Token;
+use light_macros::light_verifier_accounts;
 use light_verifier_sdk::{light_transaction::VERIFIER_STATE_SEED, state::VerifierState10Ins};
-use merkle_tree_program::{program::MerkleTreeProgram, EventMerkleTree};
-use merkle_tree_program::transaction_merkle_tree::state::TransactionMerkleTree;
-use merkle_tree_program::utils::constants::TOKEN_AUTHORITY_SEED;
+use merkle_tree_program::program::MerkleTreeProgram;
 use verifier_program_two::{self, program::VerifierProgramTwo};
 
 // Send and stores data.
@@ -40,49 +38,18 @@ pub struct LightInstructionSecond<'info, const NR_CHECKED_INPUTS: usize> {
     pub verifier_state: Account<'info, VerifierState10Ins<NR_CHECKED_INPUTS, TransactionsConfig>>,
 }
 
-
 /// Executes light transaction with state created in the first instruction.
+#[light_verifier_accounts(
+    sol,
+    spl,
+    signing_address=verifier_state.signer,
+    verifier_program_id=VerifierProgramTwo::id()
+)]
 #[derive(Accounts)]
 pub struct LightInstructionThird<'info, const NR_CHECKED_INPUTS: usize> {
-    #[account(mut, address=verifier_state.signer)]
-    pub signing_address: Signer<'info>,
     #[account(mut, seeds = [&signing_address.key().to_bytes(), VERIFIER_STATE_SEED], bump, close=signing_address )]
     pub verifier_state: Account<'info, VerifierState10Ins<NR_CHECKED_INPUTS, TransactionsConfig>>,
-    pub system_program: Program<'info, System>,
-    pub program_merkle_tree: Program<'info, MerkleTreeProgram>,
-    /// CHECK: Is the same as in integrity hash.
-    #[account(mut)]
-    pub transaction_merkle_tree: AccountLoader<'info, TransactionMerkleTree>,
-    /// CHECK: This is the cpi authority and will be enforced in the Merkle tree program.
-    #[account(mut, seeds= [MerkleTreeProgram::id().to_bytes().as_ref()], bump, seeds::program= VerifierProgramTwo::id())]
-    pub authority: UncheckedAccount<'info>,
-    pub token_program: Program<'info, Token>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub sender_spl: UncheckedAccount<'info>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub recipient_spl: UncheckedAccount<'info>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub sender_sol: UncheckedAccount<'info>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub recipient_sol: UncheckedAccount<'info>,
-    /// CHECK:` Is not checked the relayer has complete freedom.
-    #[account(mut)]
-    pub relayer_recipient_sol: UncheckedAccount<'info>,
-    /// CHECK:` Is not checked the relayer has complete freedom.
-    #[account(mut, seeds=[TOKEN_AUTHORITY_SEED], bump, seeds::program= MerkleTreeProgram::id())]
-    pub token_authority: UncheckedAccount<'info>,
-    /// CHECK: Verifier config pda which needs ot exist Is not checked the relayer has complete freedom.
-    #[account(mut, seeds= [VerifierProgramTwo::id().to_bytes().as_ref()], bump, seeds::program= MerkleTreeProgram::id())]
-    pub registered_verifier_pda: UncheckedAccount<'info>, //Account<'info, RegisteredVerifier>,
     pub verifier_program: Program<'info, VerifierProgramTwo>,
-    /// CHECK:` It get checked inside the event_call
-    pub log_wrapper: UncheckedAccount<'info>,
-    #[account(mut)]
-    pub event_merkle_tree: AccountLoader<'info, EventMerkleTree>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
The new light_verifier_accounts macro adds all accounts required in verifiers (Merkle tree PDAs, sender/recepient accounts, signers etc.) automatically without necessity to specify them manually in each verifier.