### PR TITLE
refactor: Remove info about leaves and nullifiers from `TransactionsConfig`

### DIFF
--- a/psp-template/programs_psp/{{project-name}}/src/lib.rs
+++ b/psp-template/programs_psp/{{project-name}}/src/lib.rs
@@ -37,16 +37,7 @@ pub mod {{rust-name}} {
             InstructionDataLightInstructionFirst::try_deserialize_unchecked(
                 &mut [vec![0u8; 8], inputs].concat().as_slice(),
             )?;
-        let proof = Proof {
-            a: [0u8; 64],
-            b: [0u8; 128],
-            c: [0u8; 64],
-        };
-        let public_amount = Amounts {
-            sol: inputs_des.public_amount_sol,
-            spl: inputs_des.public_amount_spl,
-        };
-        let pool_type = [0u8; 32];
+
         let mut program_id_hash = hash(&ctx.program_id.to_bytes()).to_bytes();
         program_id_hash[0] = 0;
 

--- a/psp-template/programs_psp/{{project-name}}/src/lib.rs
+++ b/psp-template/programs_psp/{{project-name}}/src/lib.rs
@@ -1,5 +1,9 @@
+use std::marker::PhantomData;
+
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::hash::hash;
+
+use light_verifier_sdk::{light_transaction::{Amounts, Proof}, state::VerifierState10Ins};
 
 pub mod psp_accounts;
 pub use psp_accounts::*;
@@ -18,8 +22,6 @@ pub const PROGRAM_ID: &str = "{{program-id}}";
 
 #[program]
 pub mod {{rust-name}} {
-    use light_verifier_sdk::light_transaction::{Amounts, Proof};
-
     use super::*;
 
     /// This instruction is the first step of a shieled transaction.
@@ -48,22 +50,34 @@ pub mod {{rust-name}} {
         let mut program_id_hash = hash(&ctx.program_id.to_bytes()).to_bytes();
         program_id_hash[0] = 0;
 
-        let mut checked_inputs: [[u8; 32]; VERIFYINGKEY_{{VERIFYING_KEY_NAME}}.nr_pubinputs] = [[0u8; 32]; VERIFYINGKEY_{{VERIFYING_KEY_NAME}}.nr_pubinputs];
-        checked_inputs[0] = program_id_hash;
-        checked_inputs[1] = inputs_des.transaction_hash;
+        let mut checked_public_inputs: [[u8; 32]; VERIFYINGKEY_{{VERIFYING_KEY_NAME}}.nr_pubinputs] = [[0u8; 32]; VERIFYINGKEY_{{VERIFYING_KEY_NAME}}.nr_pubinputs];
+        checked_public_inputs[0] = program_id_hash;
+        checked_public_inputs[1] = inputs_des.transaction_hash;
 
-        process_psp_instruction_first::<{ VERIFYINGKEY_{{VERIFYING_KEY_NAME}}.nr_pubinputs }, 17>(
-            ctx,
-            &proof,
-            &public_amount,
-            &inputs_des.input_nullifier,
-            &inputs_des.output_commitment,
-            &checked_inputs,
-            &inputs_des.encrypted_utxos,
-            &pool_type,
-            &inputs_des.root_index,
-            &inputs_des.relayer_fee,
-        )
+        let state = VerifierState10Ins {
+            merkle_root_index: inputs_des.root_index,
+            signer: Pubkey::from([0u8; 32]),
+            nullifiers: inputs_des.input_nullifier.to_vec(),
+            leaves: inputs_des.output_commitment.to_vec(),
+            public_amount_spl: inputs_des.public_amount_spl,
+            public_amount_sol: inputs_des.public_amount_sol,
+            mint_pubkey: [0u8; 32],
+            merkle_root: [0u8; 32],
+            tx_integrity_hash: [0u8; 32],
+            relayer_fee: inputs_des.relayer_fee,
+            encrypted_utxos: inputs_des.encrypted_utxos,
+            checked_public_inputs,
+            proof_a: [0u8; 64],
+            proof_b: [0u8; 128],
+            proof_c: [0u8; 64],
+            transaction_hash: [0u8; 32],
+            e_phantom: PhantomData,
+        };
+
+        ctx.accounts.verifier_state.set_inner(state);
+        ctx.accounts.verifier_state.signer = *ctx.accounts.signing_address.key;
+
+        Ok(())
     }
 
     pub fn light_instruction_second<'a, 'b, 'c, 'info>(

--- a/psp-template/programs_psp/{{project-name}}/src/processor.rs
+++ b/psp-template/programs_psp/{{project-name}}/src/processor.rs
@@ -1,70 +1,19 @@
 use crate::verifying_key_{{circom-name}}::VERIFYINGKEY_{{VERIFYING_KEY_NAME}};
-use crate::LightInstructionFirst;
 use crate::LightInstructionThird;
 use anchor_lang::prelude::*;
 use light_macros::pubkey;
-use light_verifier_sdk::light_transaction::Amounts;
 use light_verifier_sdk::light_transaction::Proof;
-use light_verifier_sdk::light_transaction::TransactionInput;
 use light_verifier_sdk::light_transaction::VERIFIER_STATE_SEED;
 use light_verifier_sdk::{
     light_app_transaction::AppTransaction,
-    light_transaction::{Config, Transaction},
+    light_transaction::Config,
 };
 
 #[derive(Clone)]
 pub struct TransactionsConfig;
 impl Config for TransactionsConfig {
-    /// Number of nullifiers to be inserted with the transaction.
-    const NR_NULLIFIERS: usize = 4;
-    /// Number of output utxos.
-    const NR_LEAVES: usize = 4;
     /// ProgramId.
     const ID: Pubkey = pubkey!("{{program-id}}");
-}
-
-pub fn process_psp_instruction_first<
-    'a,
-    'b,
-    'c,
-    'info,
-    const NR_CHECKED_INPUTS: usize,
-    const NR_PUBLIC_INPUTS: usize,
->(
-    ctx: Context<'a, 'b, 'c, 'info, LightInstructionFirst<'info, NR_CHECKED_INPUTS>>,
-    proof: &'a Proof,
-    public_amount: &'a Amounts,
-    input_nullifier: &'a [[u8; 32]; 4],
-    output_commitment: &'a [[u8; 32]; 4],
-    checked_public_inputs: &'a [[u8; 32]; NR_CHECKED_INPUTS],
-    encrypted_utxos: &'a Vec<u8>,
-    pool_type: &'a [u8; 32],
-    root_index: &'a u64,
-    relayer_fee: &'a u64,
-) -> Result<()> {
-    let output_commitment = [
-        [output_commitment[0], output_commitment[1]],
-        [output_commitment[2], output_commitment[3]],
-    ];
-    let input = TransactionInput {
-        message: None,
-        proof,
-        public_amount,
-        nullifiers: input_nullifier,
-        leaves: &output_commitment,
-        encrypted_utxos,
-        relayer_fee: *relayer_fee,
-        merkle_root_index: (*root_index).try_into().unwrap(),
-        pool_type,
-        checked_public_inputs,
-        accounts: None,
-        verifyingkey: &VERIFYINGKEY_{{VERIFYING_KEY_NAME}},
-    };
-    let tx =
-        Transaction::<NR_CHECKED_INPUTS, 2, 4, NR_PUBLIC_INPUTS, TransactionsConfig>::new(input);
-    ctx.accounts.verifier_state.set_inner(tx.into());
-    ctx.accounts.verifier_state.signer = *ctx.accounts.signing_address.key;
-    Ok(())
 }
 
 pub fn cpi_verifier_two<'a, 'b, 'c, 'info, const NR_CHECKED_INPUTS: usize>(


### PR DESCRIPTION


It was removed in the main Light Protocol repo.