### PR TITLE
Update to latest Light Protocol (program) changes

### DIFF
--- a/psp-template/cargo-generate.toml
+++ b/psp-template/cargo-generate.toml
@@ -32,9 +32,13 @@ prompt = "Prover js version"
 type = "string"
 prompt = "zk js version"
 
-[placeholders.light-system-programs-version]
+[placeholders.light-merkle-tree-program-version]
 type = "string"
-prompt = "On-chain programs version"
+prompt = "Merkle tree program version"
+
+[placeholders.light-psp4in4out-version]
+type = "string"
+prompt = "Native PSP (4 inputs, 4 outputs) version"
 
 [placeholders.light-macros-version]
 type = "string"

--- a/psp-template/programs_psp/{{project-name}}/Cargo.toml
+++ b/psp-template/programs_psp/{{project-name}}/Cargo.toml
@@ -18,8 +18,8 @@ default = []
 [dependencies]
 anchor-lang = "0.28.0"
 anchor-spl = "0.28.0"
-merkle_tree_program = {{ light-system-programs-version }}
-verifier_program_two = {{ light-system-programs-version }}
+light-merkle-tree-program = {{ light-merkle-tree-program-version }}
+light-psp4in4out = {{ light-psp4in4out-version }}
 light-macros = {{ light-macros-version }}
 light-verifier-sdk = {{ light-verifier-sdk-version }}
 solana-program = "1.16.4"

--- a/psp-template/programs_psp/{{project-name}}/src/processor.rs
+++ b/psp-template/programs_psp/{{project-name}}/src/processor.rs
@@ -40,8 +40,8 @@ pub fn cpi_verifier_two<'a, 'b, 'c, 'info, const NR_CHECKED_INPUTS: usize>(
     let cpi_seed = &[seed, domain_separation_seed, &bump[..]];
     let final_seed = &[&cpi_seed[..]];
 
-    let accounts: verifier_program_two::cpi::accounts::LightInstruction<'info> =
-        verifier_program_two::cpi::accounts::LightInstruction {
+    let accounts: light_psp4in4out::cpi::accounts::LightInstruction<'info> =
+        light_psp4in4out::cpi::accounts::LightInstruction {
             verifier_state: ctx.accounts.verifier_state.to_account_info(),
             signing_address: ctx.accounts.signing_address.to_account_info(),
             authority: ctx.accounts.authority.to_account_info(),
@@ -68,7 +68,7 @@ pub fn cpi_verifier_two<'a, 'b, 'c, 'info, const NR_CHECKED_INPUTS: usize>(
     );
     cpi_ctx = cpi_ctx.with_remaining_accounts(ctx.remaining_accounts.to_vec());
 
-    verifier_program_two::cpi::shielded_transfer_inputs(
+    light_psp4in4out::cpi::shielded_transfer_inputs(
         cpi_ctx,
         proof_verifier.a,
         proof_verifier.b,

--- a/psp-template/programs_psp/{{project-name}}/src/psp_accounts.rs
+++ b/psp-template/programs_psp/{{project-name}}/src/psp_accounts.rs
@@ -1,9 +1,9 @@
 use crate::processor::TransactionsConfig;
 use anchor_lang::prelude::*;
 use light_macros::light_verifier_accounts;
+use light_merkle_tree_program::program::LightMerkleTreeProgram;
+use light_psp_4in4out::{self, program::LightPsp4in4out};
 use light_verifier_sdk::{light_transaction::VERIFIER_STATE_SEED, state::VerifierState10Ins};
-use merkle_tree_program::program::MerkleTreeProgram;
-use verifier_program_two::{self, program::VerifierProgramTwo};
 
 // Send and stores data.
 #[derive(Accounts)]
@@ -43,13 +43,13 @@ pub struct LightInstructionSecond<'info, const NR_CHECKED_INPUTS: usize> {
     sol,
     spl,
     signing_address=verifier_state.signer,
-    verifier_program_id=VerifierProgramTwo::id()
+    verifier_program_id=LightPsp4in4out::id()
 )]
 #[derive(Accounts)]
 pub struct LightInstructionThird<'info, const NR_CHECKED_INPUTS: usize> {
     #[account(mut, seeds = [&signing_address.key().to_bytes(), VERIFIER_STATE_SEED], bump, close=signing_address )]
     pub verifier_state: Account<'info, VerifierState10Ins<NR_CHECKED_INPUTS, TransactionsConfig>>,
-    pub verifier_program: Program<'info, VerifierProgramTwo>,
+    pub verifier_program: Program<'info, LightPsp4in4out>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
* Include name changes:
  * `merkle-tree-program` -> `light-merkle-tree-program`
  * `verifier-program-two` -> `light-psp4in4out`
* Define version for each program separately.